### PR TITLE
Add Netcontrol

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -42,3 +42,7 @@ PROTOCOL=http
 # website
 FRONTEND_API_URL="api.beta.gate.localhost"
 FRONTEND_NODE_ENV=development
+
+# Netcontrol configuration
+NETCONTROL_MARK='[100, 2]'
+NETCONTROL_SOCKET_FILE='/var/run/langate3000-netcontrol.sock\\'

--- a/.env.dist
+++ b/.env.dist
@@ -45,4 +45,4 @@ FRONTEND_NODE_ENV=development
 
 # Netcontrol configuration
 NETCONTROL_MARK='[100, 2]'
-NETCONTROL_SOCKET_FILE='/var/run/langate3000-netcontrol.sock\\'
+NETCONTROL_SOCKET_FILE='/var/run/langate3000-netcontrol.sock'

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "netcontrol"]
+	path = netcontrol
+	url = https://github.com/InsaLan/langate2000-netcontrol

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ WORKING_DIR := $(shell pwd)
 
 install:
 	@echo "Installing netcontrol"
-	@echo "Working directory: ${WORKING_DIR}"
 	cp langate3000-netcontrol.service /etc/systemd/system/
 	sed -i 's|__WORKING_DIR__|${WORKING_DIR}|g' /etc/systemd/system/langate3000-netcontrol.service
 
@@ -13,7 +12,7 @@ build-prod:
 	docker compose -f docker-compose.yml build
 
 run-prod:
-  systemctl start langate2000-netcontrol
+	systemctl start langate2000-netcontrol
 	@echo "Running the production stack"
 	docker compose -f docker-compose.yml up -d
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,19 @@
-@PHONY: build-prod run-prod stop-prod clean-all clean-custom
+@PHONY: install build-prod run-prod stop-prod clean-all clean-custom
+
+WORKING_DIR := $(shell pwd)
+
+install:
+	@echo "Installing netcontrol"
+	@echo "Working directory: ${WORKING_DIR}"
+	cp langate3000-netcontrol.service /etc/systemd/system/
+	sed -i 's|__WORKING_DIR__|${WORKING_DIR}|g' /etc/systemd/system/langate3000-netcontrol.service
 
 build-prod:
 	@echo "Building production images"
 	docker compose -f docker-compose.yml build
 
 run-prod:
+  systemctl start langate2000-netcontrol
 	@echo "Running the production stack"
 	docker compose -f docker-compose.yml up -d
 
@@ -17,7 +26,7 @@ run-beta:
 	docker compose -f docker-compose-beta.yml up --build -d
 
 stop-beta:
-	@echo "Stopping the pre-production stack" 
+	@echo "Stopping the pre-production stack"
 	docker compose -f docker-compose-beta.yml down
 
 clean-all:

--- a/README.md
+++ b/README.md
@@ -1,14 +1,28 @@
-# insalan.fr infrastructure
+# Langate 3000 infrastructure
 
 This repository is here to hold the langate infrastructure. It is composed of
 the frontend, the backend, and the nginx server.
 
-# Contributing
+## Contributing
 
 Please read carefully[the CONTRIBUTING.md file](CONTRIBUTING.md) before any
 contribution.
 
-## Installing and running insalan.fr in local
+## Netcontrol
+
+The netcontrol component is an interface between the langate web pages and
+the kernel network components of the gateway used during the events.
+
+Having this component in between is important because we don't want the web server
+to have privileged access to kernel components as it is needed for this script.
+
+Both the langate web server and this components communicate using UNIX sockets.
+The messages exchanged begin with the size of the payload (as a 4 bytes int) followed by
+the payload itself. The payload is always a pickle-encoded python dict.
+
+launch command `make install` for the first setup of the langate on your computer, that will copy netcontrol.service in systemd.
+
+## Installing and running the langate in local
 
 ```sh
 git clone git@github.com:InsaLan/langate-3000.git

--- a/backend/langate/modules/netcontrol.py
+++ b/backend/langate/modules/netcontrol.py
@@ -1,0 +1,52 @@
+import sys, socket, struct
+import pickle
+import threading
+from ..settings import NETCONTROL_MARK, NETCONTROL_SOCKET_FILE
+
+lock = threading.Lock()
+
+class NetworkDaemonError(RuntimeError):
+    """ every error originating from netcontrol raise this exception  """
+
+def _send(sock, data):
+    pack = struct.pack('>I', len(data)) + data
+    sock.sendall(pack)
+
+def _recv_bytes(sock, size):
+    data = b''
+    while len(data) < size:
+        r = sock.recv(size - len(data))
+        if not r:
+            return None
+        data += r
+    return data
+
+def _recv(sock):
+    data_length_r = _recv_bytes(sock, 4)
+
+    if not data_length_r:
+        return None
+
+    data_length = struct.unpack('>I', data_length_r)[0]
+    return _recv_bytes(sock, data_length)
+
+
+def communicate(payload):
+    with lock:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+            sock.connect(NETCONTROL_SOCKET_FILE)
+            r = pickle.dumps(payload)
+            _send(sock, r)
+
+            response_r = _recv(sock)
+            response = pickle.loads(response_r)
+
+            if response["success"]:
+                return response
+
+            else:
+                raise NetworkDaemonError(response["message"])
+
+def query(q, opts = {}):
+    b = { "query": q }
+    return communicate({ **b, **opts })

--- a/backend/langate/settings.py
+++ b/backend/langate/settings.py
@@ -216,3 +216,7 @@ CSRF_COOKIE_DOMAIN = '.' + getenv("WEBSITE_HOST", "localhost")
 
 # Session cookie settings
 SESSION_COOKIE_AGE = int(getenv("SESSION_COOKIE_AGE", "1209600"))
+
+# Netcontrol settings
+NETCONTROL_MARK = json.loads(getenv("NETCONTROL_MARK", "[100, 2]"))
+NETCONTROL_SOCKET_FILE = getenv("NETCONTROL_SOCKET_FILE", "/var/run/langate3000-netcontrol.sock")

--- a/docker-compose-beta.yml
+++ b/docker-compose-beta.yml
@@ -22,10 +22,12 @@ services:
       DJANGO_SECRET: ${BACKEND_DJANGO_SECRET}
       SESSION_COOKIE_AGE: ${SESSION_COOKIE_AGE}
       DEV: ${DEV}
-
+      NETCONTROL_MARK: ${NETCONTROL_MARK}
+      NETCONTROL_SOCKET_FILE: ${NETCONTROL_SOCKET_FILE}
     volumes:
       - ./volumes/beta/backend:/app/v1
       - ./backend:/app
+      - ${NETCONTROL_SOCKET_FILE}:${NETCONTROL_SOCKET_FILE}
     expose:
       - 8000
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,8 +31,11 @@ services:
       HELLOASSO_ERROR_URL: ${HELLOASSO_ERROR_URL}
       RIOT_API_KEY: ${RIOT_API_KEY}
       DEV: 0
+      NETCONTROL_MARK: ${NETCONTROL_MARK}
+      NETCONTROL_SOCKET_FILE: ${NETCONTROL_SOCKET_FILE}
     volumes:
       - ./volumes/prod/backend:/app/v1
+      - ${NETCONTROL_SOCKET_FILE}:${NETCONTROL_SOCKET_FILE}
     expose:
       - 8000
     networks:
@@ -79,7 +82,7 @@ services:
       - ./volumes/prod/frontend:/src/dist
     networks:
       - backend
-  
+
   nginx:
     image: nginx
     restart: unless-stopped

--- a/langate3000-netcontrol.service
+++ b/langate3000-netcontrol.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=langate3000-netcontrol
+After=network.target
+StartLimitIntervalSec=0
+[Service]
+Type=simple
+Restart=always
+RestartSec=1
+User=root
+ExecStart=/usr/bin/python3 __WORKING_DIR__/netcontrol/netcontrol.py
+WorkingDirectory=__WORKING_DIR__/netcontrol
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Description

Add netcontrol infrastructure (service and module) to interact with the ipset command on host.
The netcontrol module has been tested with local setup, "connect" and "user_info" queries.
Even with the thread lock, it keep the website asynchronous for other pages. 

## Checklist

- [x] I have tested the changes locally and they work as expected.
- [N/A] I have tested the responsiveness of the changes and they work as expected.
- [X] I have assigned the pull request to the appropriate reviewer(s).
- [X] I have added labels to the pull request, if necessary.

## Related Issues

Fix #2 
