### PR TITLE
Enable backend/netcontrol communication

### DIFF
--- a/backend/langate/modules/netcontrol.py
+++ b/backend/langate/modules/netcontrol.py
@@ -17,25 +17,17 @@ class Netcontrol:
         """
         response = None
 
-        # Construct the data to be sent in the request
-        if len(args) == 1:
-            data = '/' + next(iter(args.items()))[1]
-        elif len(args) > 1:
-            data = '?' + "&".join([f"{key}={value}" for key, value in args.items()])
-        else:
-            data = ''
-
         # Make the request
         try:
             # Check the type of request
             if endpoint in GET_REQUESTS:
-                response = requests.get(self.REQUEST_URL + endpoint + data)
+                response = requests.get(self.REQUEST_URL + endpoint, params=args)
             elif endpoint in POST_REQUESTS:
-                response = requests.post(self.REQUEST_URL + endpoint + data)
+                response = requests.post(self.REQUEST_URL + endpoint, params=args)
             elif endpoint in DELETE_REQUESTS:
-                response = requests.delete(self.REQUEST_URL + endpoint + data)
+                response = requests.delete(self.REQUEST_URL + endpoint, params=args)
             elif endpoint in PUT_REQUESTS:
-                response = requests.put(self.REQUEST_URL + endpoint + data)
+                response = requests.put(self.REQUEST_URL + endpoint, params=args)
             
             response.raise_for_status()
             return response.json()

--- a/backend/langate/modules/netcontrol.py
+++ b/backend/langate/modules/netcontrol.py
@@ -15,7 +15,7 @@ class RequestError(Exception):
         self.message = message
         super().__init__(self.message)
 
-class NetControl:
+class Netcontrol:
     """
     Class which interacts with the netcontrol API.
     """
@@ -60,7 +60,7 @@ class NetControl:
                 response = requests.put(f"http://{self.HOST_IP}:6784/{endpoint}{data}")
             
             # Check for errors in the response
-            if "error" in response.json().keys():
+            if response.json()["error"]:
                 raise RequestError(response.json()["error"])
             return response.json()
         

--- a/backend/langate/modules/netcontrol.py
+++ b/backend/langate/modules/netcontrol.py
@@ -1,52 +1,114 @@
-import  socket, struct
-import pickle
-import threading
-from ..settings import NETCONTROL_SOCKET_FILE
+import requests
+import subprocess
+import logging
 
-lock = threading.Lock()
+GET_REQUESTS = ["get_mac", "get_ip"]
+POST_REQUESTS = ["connect_user"]
+DELETE_REQUESTS = ["disconnect_user"]
+PUT_REQUESTS = ["set_mark"]
 
-class NetworkDaemonError(RuntimeError):
-    """ every error originating from netcontrol raise this exception  """
+class RequestError(Exception):
+    """
+    Exception raised when a request to the netcontrol API fails.
+    """
+    def __init__(self, message):
+        self.message = message
+        super().__init__(self.message)
 
-def _send(sock, data):
-    pack = struct.pack('>I', len(data)) + data
-    sock.sendall(pack)
+class NetControl:
+    """
+    Class which interacts with the netcontrol API.
+    """
+    def __init__(self):
+        """
+        Initialize HOST_IP to the docker's default route and check the connection with the netcontrol API.
+        """
+        self.HOST_IP = subprocess.run(["/sbin/ip", "route"], capture_output=True).stdout.decode("utf-8").split()[2]
+        self.logger = logging.getLogger(__name__)
 
-def _recv_bytes(sock, size):
-    data = b''
-    while len(data) < size:
-        r = sock.recv(size - len(data))
-        if not r:
-            return None
-        data += r
-    return data
+        try:
+            self.logger.info("Checking connection with the netcontrol API...")
+            if requests.get(f"http://{self.HOST_IP}:6784/") != "netcontrol is running":
+                raise RequestError("Netcontrol is not running.")
+        except requests.exceptions.ConnectionError:
+            self.logger.info("Could not connect to the netcontrol API.")
+        except RequestError as e:
+            self.logger.info(e.message)
 
-def _recv(sock):
-    data_length_r = _recv_bytes(sock, 4)
+    def request(self, endpoint='', args={}):
+        """
+        Make a given request to the netcontrol API.
+        """
+        # Construct the data to be sent in the request
+        if len(args) == 1:
+            data = '/'+args[0]
+        elif len(args) > 1:
+            data = '?' + "&".join([f"{key}={value}" for key, value in args.items()])
+        else:
+            data = ''
 
-    if not data_length_r:
-        return None
+        # Make the request
+        try:
+            # Check the type of request
+            if endpoint in GET_REQUESTS:
+                response = requests.get(f"http://{self.HOST_IP}:6784/{endpoint}{data}")
+            elif endpoint in POST_REQUESTS:
+                response = requests.post(f"http://{self.HOST_IP}:6784/{endpoint}{data}")
+            elif endpoint in DELETE_REQUESTS:
+                response = requests.delete(f"http://{self.HOST_IP}:6784/{endpoint}{data}")
+            elif endpoint in PUT_REQUESTS:
+                response = requests.put(f"http://{self.HOST_IP}:6784/{endpoint}{data}")
+            
+            # Check for errors in the response
+            if "error" in response.json().keys():
+                raise RequestError(response.json()["error"])
+            return response.json()
+        
+        # Handle exceptions
+        except requests.exceptions.ConnectionError:
+            self.logger.info("Could not connect to the netcontrol API.")
+        except RequestError as e:
+            self.logger.info(e.message)
 
-    data_length = struct.unpack('>I', data_length_r)[0]
-    return _recv_bytes(sock, data_length)
+    def check_api(self):
+        """
+        Check if the netcontrol API is running.
+        """
+        self.logger.info("Checking connection with the netcontrol API...")
+        return self.request()
 
-
-def communicate(payload):
-    with lock:
-        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
-            sock.connect(NETCONTROL_SOCKET_FILE)
-            r = pickle.dumps(payload)
-            _send(sock, r)
-
-            response_r = _recv(sock)
-            response = pickle.loads(response_r)
-
-            if response["success"]:
-                return response
-
-            else:
-                raise NetworkDaemonError(response["message"])
-
-def query(q, opts = {}):
-    b = { "query": q }
-    return communicate({ **b, **opts })
+    def get_mac(self, ip: str):
+        """
+        Get the MAC address of the device with the given IP address.
+        """
+        self.logger.info(f"Getting MAC address of {ip}...")
+        return self.request("get_mac", {"ip": ip})["mac"]
+    
+    def get_ip(self, mac: str):
+        """
+        Get the IP address of the device with the given MAC address.
+        """
+        self.logger.info(f"Getting IP address of {mac}...")
+        return self.request("get_ip", {"mac": mac})["ip"]
+    
+    def connect_user(self, mac: str, mark: int, name: str):
+        """
+        Connect the user with the given MAC address.
+        """
+        self.logger.info(f"Connecting user with MAC address {mac} ({name})...")
+        return self.request("connect_user", {"mac": mac, "mark": mark, "name": name})
+    
+    def disconnect_user(self, mac: str):
+        """
+        Disconnect the user with the given MAC address.
+        """
+        self.logger.info(f"Disconnecting user with MAC address {mac}...")
+        return self.request("disconnect_user", {"mac": mac})
+    
+    def set_mark(self, mac: str, mark: int):
+        """
+        Set the mark of the user with the given MAC address.
+        """
+        self.logger.info(f"Setting mark of user with MAC address {mac} to {mark}...")
+        return self.request("set_mark", {"mac": mac, "mark": mark})
+    

--- a/backend/langate/modules/netcontrol.py
+++ b/backend/langate/modules/netcontrol.py
@@ -1,7 +1,6 @@
 import requests
 import subprocess
 import logging
-from fastapi import HTTPException
 
 GET_REQUESTS = ["get_mac", "get_ip"]
 POST_REQUESTS = ["connect_user"]
@@ -21,17 +20,7 @@ class Netcontrol:
 
         self.logger = logging.getLogger(__name__)
 
-        # Check the connection with the netcontrol API
-        try:
-            try:
-                self.logger.info("Checking connection with the netcontrol API...")
-                if requests.get(self.REQUEST_URL) != "netcontrol is running":
-                    raise HTTPException(status_code=404, detail="Netcontrol is not running.")
-                
-            except requests.exceptions.ConnectionError:
-                raise HTTPException(status_code=408, detail="Could not connect to the netcontrol API.")
-        except HTTPException as e:
-            self.logger.info(e.detail)
+        self.check_api()
 
     def request(self, endpoint='', args={}):
         """
@@ -62,9 +51,9 @@ class Netcontrol:
                 return response.json()
             
             except requests.exceptions.ConnectionError:
-                raise HTTPException(status_code=408, detail="Could not connect to the netcontrol API.")
-        except HTTPException as e:
-            self.logger.info(e.detail) # Handle HTTP exception (TODO)
+                raise requests.HTTPError("Could not connect to the netcontrol API.")
+        except requests.HTTPError as e:
+            self.logger.info(e) # Handle HTTP exception (TODO)
 
     def check_api(self):
         """

--- a/backend/langate/modules/netcontrol.py
+++ b/backend/langate/modules/netcontrol.py
@@ -67,8 +67,10 @@ class Netcontrol:
         # Handle exceptions
         except requests.exceptions.ConnectionError:
             self.logger.info("Could not connect to the netcontrol API.")
+            return {"error": "Could not connect to the netcontrol API."}
         except RequestError as e:
             self.logger.info(e.message)
+            return response.json()
 
     def check_api(self):
         """

--- a/backend/langate/modules/netcontrol.py
+++ b/backend/langate/modules/netcontrol.py
@@ -1,19 +1,12 @@
 import requests
 import subprocess
 import logging
+from fastapi import HTTPException
 
 GET_REQUESTS = ["get_mac", "get_ip"]
 POST_REQUESTS = ["connect_user"]
 DELETE_REQUESTS = ["disconnect_user"]
 PUT_REQUESTS = ["set_mark"]
-
-class RequestError(Exception):
-    """
-    Exception raised when a request to the netcontrol API fails.
-    """
-    def __init__(self, message):
-        self.message = message
-        super().__init__(self.message)
 
 class Netcontrol:
     """
@@ -21,19 +14,24 @@ class Netcontrol:
     """
     def __init__(self):
         """
-        Initialize HOST_IP to the docker's default route and check the connection with the netcontrol API.
+        Initialize HOST_IP to the docker's default route, set up REQUEST_URL and check the connection with the netcontrol API.
         """
         self.HOST_IP = subprocess.run(["/sbin/ip", "route"], capture_output=True).stdout.decode("utf-8").split()[2]
+        self.REQUEST_URL = f"http://{self.HOST_IP}:6784/"
+
         self.logger = logging.getLogger(__name__)
 
+        # Check the connection with the netcontrol API
         try:
-            self.logger.info("Checking connection with the netcontrol API...")
-            if requests.get(f"http://{self.HOST_IP}:6784/") != "netcontrol is running":
-                raise RequestError("Netcontrol is not running.")
-        except requests.exceptions.ConnectionError:
-            self.logger.info("Could not connect to the netcontrol API.")
-        except RequestError as e:
-            self.logger.info(e.message)
+            try:
+                self.logger.info("Checking connection with the netcontrol API...")
+                if requests.get(self.REQUEST_URL) != "netcontrol is running":
+                    raise HTTPException(status_code=404, detail="Netcontrol is not running.")
+                
+            except requests.exceptions.ConnectionError:
+                raise HTTPException(status_code=408, detail="Could not connect to the netcontrol API.")
+        except HTTPException as e:
+            self.logger.info(e.detail)
 
     def request(self, endpoint='', args={}):
         """
@@ -49,28 +47,24 @@ class Netcontrol:
 
         # Make the request
         try:
-            # Check the type of request
-            if endpoint in GET_REQUESTS:
-                response = requests.get(f"http://{self.HOST_IP}:6784/{endpoint}{data}")
-            elif endpoint in POST_REQUESTS:
-                response = requests.post(f"http://{self.HOST_IP}:6784/{endpoint}{data}")
-            elif endpoint in DELETE_REQUESTS:
-                response = requests.delete(f"http://{self.HOST_IP}:6784/{endpoint}{data}")
-            elif endpoint in PUT_REQUESTS:
-                response = requests.put(f"http://{self.HOST_IP}:6784/{endpoint}{data}")
+            try:
+                # Check the type of request
+                if endpoint in GET_REQUESTS:
+                    response = requests.get(self.REQUEST_URL + endpoint + data)
+                elif endpoint in POST_REQUESTS:
+                    response = requests.post(self.REQUEST_URL + endpoint + data)
+                elif endpoint in DELETE_REQUESTS:
+                    response = requests.delete(self.REQUEST_URL + endpoint + data)
+                elif endpoint in PUT_REQUESTS:
+                    response = requests.put(self.REQUEST_URL + endpoint + data)
+                
+                response.raise_for_status()
+                return response.json()
             
-            # Check for errors in the response
-            if response.json()["error"]:
-                raise RequestError(response.json()["error"])
-            return response.json()
-        
-        # Handle exceptions
-        except requests.exceptions.ConnectionError:
-            self.logger.info("Could not connect to the netcontrol API.")
-            return {"error": "Could not connect to the netcontrol API."}
-        except RequestError as e:
-            self.logger.info(e.message)
-            return response.json()
+            except requests.exceptions.ConnectionError:
+                raise HTTPException(status_code=408, detail="Could not connect to the netcontrol API.")
+        except HTTPException as e:
+            self.logger.info(e.detail) # Handle HTTP exception (TODO)
 
     def check_api(self):
         """

--- a/backend/langate/network/apps.py
+++ b/backend/langate/network/apps.py
@@ -54,11 +54,11 @@ class NetworkConfig(AppConfig):
                 else:
                     connect_res = netcontrol.connect_user(dev.mac, dev.mark, dev.name)
                 if connect_res["error"]:
-                    logger.info("[PortalConfig] Could not connect device %s", dev.mac)
+                    logger.info("[PortalConfig] %s", connect_res["error"])
 
                 mark_res = netcontrol.set_mark(dev.mac, dev.mark)
                 if mark_res["error"]:
-                    logger.info("[PortalConfig] Could not set mark for device %s", dev.name)
+                    logger.info("[PortalConfig] %s", connect_res["error"])
 
             logger.info(_("[PortalConfig] Add default whitelist devices to the ipset"))
             if os.path.exists("assets/misc/whitelist.txt"):

--- a/backend/langate/network/apps.py
+++ b/backend/langate/network/apps.py
@@ -8,7 +8,7 @@ import os
 from django.apps import AppConfig
 from django.utils.translation import gettext_lazy as _
 
-from ..modules import netcontrol
+from langate.settings import netcontrol
 from langate.settings import SETTINGS
 
 logger = logging.getLogger(__name__)
@@ -50,14 +50,14 @@ class NetworkConfig(AppConfig):
             for dev in Device.objects.all():
                 userdevice = UserDevice.objects.filter(mac=dev.mac).first()
                 if userdevice is not None:
-                    connect_res = netcontrol.query("connect_user", {"mac": userdevice.mac, "name": userdevice.user.username})
+                    connect_res = netcontrol.connect_user(userdevice.mac, userdevice.mark, userdevice.user.username)
                 else:
-                    connect_res = netcontrol.query("connect_user", {"mac": dev.mac, "name": dev.name})
-                if not connect_res["success"]:
+                    connect_res = netcontrol.connect_user(dev.mac, dev.mark, dev.name)
+                if connect_res["error"]:
                     logger.info("[PortalConfig] Could not connect device %s", dev.mac)
 
-                mark_res = netcontrol.query("set_mark", {"mac": dev.mac, "mark": dev.mark})
-                if not mark_res["success"]:
+                mark_res = netcontrol.set_mark(dev.mac, dev.mark)
+                if mark_res["error"]:
                     logger.info("[PortalConfig] Could not set mark for device %s", dev.name)
 
             logger.info(_("[PortalConfig] Add default whitelist devices to the ipset"))
@@ -76,12 +76,12 @@ class NetworkConfig(AppConfig):
                                 dev.whitelisted = True
                                 dev.save()
 
-                                connect_res = netcontrol.query("connect_user", {"mac": dev.mac, "name": dev.name})
-                                if not connect_res["success"]:
+                                connect_res = netcontrol.connect_user(dev.mac, dev.mark, dev.name)
+                                if connect_res["error"]:
                                     logger.info("[PortalConfig] Could not connect device %s", dev.mac)
 
-                                mark_res = netcontrol.query("set_mark", {"mac": dev.mac, "mark": mark})
-                                if not mark_res["success"]:
+                                mark_res = netcontrol.set_mark(dev.mac, mark)
+                                if mark_res["error"]:
                                     logger.info("[PortalConfig] Could not set mark for device %s", dev.name)
                         else:
                             logger.error("[PortalConfig] Invalid line in whitelist.txt: %s", line)

--- a/backend/langate/network/models.py
+++ b/backend/langate/network/models.py
@@ -8,7 +8,7 @@ from django.utils.translation import gettext_lazy as _
 from django.core.exceptions import ValidationError
 
 from langate.user.models import User
-from langate.modules import netcontrol
+from langate.settings import netcontrol
 from langate.settings import SETTINGS
 
 from .utils import generate_dev_name, get_mark
@@ -64,8 +64,7 @@ class DeviceManager(models.Manager):
         # Validate the MAC address
         validate_mac(mac)
 
-        netcontrol.query("connect", { "mac": mac, "name": name })
-        netcontrol.query("set_mark", { "mac": mac, "mark": mark })
+        netcontrol.connect_user(mac, mark, name)
         logger.info("Connected device %s (the mac %s has been connected)", name, mac)
 
         try:
@@ -73,7 +72,7 @@ class DeviceManager(models.Manager):
             device.save()
             return device
         except Exception as e:
-            netcontrol.query("disconnect_user", { "mac": mac })
+            netcontrol.disconnect_user(mac)
             raise ValidationError(
               _("There was an error creating the device. Please try again.")
             ) from e
@@ -83,7 +82,7 @@ class DeviceManager(models.Manager):
         """
         Delete a device with the given mac address
         """
-        netcontrol.query("disconnect_user", { "mac": mac })
+        netcontrol.disconnect_user(mac)
         logger.info("Disconnected device %s from the internet.", mac)
 
         device = Device.objects.get(mac=mac)
@@ -98,16 +97,14 @@ class DeviceManager(models.Manager):
         if not name:
             name = generate_dev_name()
 
-        r = netcontrol.query("get_mac", { "ip": ip })
+        r = netcontrol.get_mac(ip)
         mac = r["mac"]
 
         # Validate the MAC address
         validate_mac(mac)
 
-        netcontrol.query("connect_user", { "mac": mac, "name": user.username })
-
         mark = get_mark(user)
-        netcontrol.query("set_mark", { "mac": mac, "mark": mark })
+        netcontrol.connect_user(mac, mark, user.username)
 
         logger.info(
             "Connected device %s (owned by %s) at %s to the internet.",
@@ -121,7 +118,7 @@ class DeviceManager(models.Manager):
             device.save()
             return device
         except Exception as e:
-            netcontrol.query("disconnect_user", { "mac": mac })
+            netcontrol.disconnect_user(mac)
             raise ValidationError(
               _("There was an error creating the device. Please try again.")
             ) from e
@@ -142,19 +139,18 @@ class DeviceManager(models.Manager):
         if name and name != device.name:
             device.name = name
         if mac and mac != device.mac:
-          validate_mac(mac)
-          # Disconnect the old MAC
-          netcontrol.query("disconnect_user", { "mac": device.mac })
-
-          # Connect the new MAC
-          netcontrol.query("connect", { "mac": mac, "name": device.name })
-          device.mac = mac
+            validate_mac(mac)
+            # Disconnect the old MAC
+            netcontrol.disconnect_user(device.mac)
+            # Connect the new MAC
+            netcontrol.connect_user(mac, device.mark, device.name)
+            device.mac = mac
         if mark and mark != device.mark:
             # Check if the mark is valid
             if mark not in [m["value"] for m in SETTINGS["marks"]]:
                 raise ValidationError(_("Invalid mark"))
             device.mark = mark
-            netcontrol.query("set_mark", { "mac": device.mac, "mark": mark })
+            netcontrol.set_mark(device.mac, mark)
 
         try:
             device.save()

--- a/backend/langate/network/models.py
+++ b/backend/langate/network/models.py
@@ -1,3 +1,4 @@
+import requests
 import random, logging
 import re
 
@@ -64,15 +65,25 @@ class DeviceManager(models.Manager):
         # Validate the MAC address
         validate_mac(mac)
 
-        netcontrol.connect_user(mac, mark, name)
-        logger.info("Connected device %s (the mac %s has been connected)", name, mac)
+        try:
+            netcontrol.connect_user(mac, mark, name)
+            logger.info("Connected device %s (the mac %s has been connected)", name, mac)
+        except requests.HTTPError as e:
+            raise ValidationError(
+              _("Could not connect user.")
+            ) from e
 
         try:
             device = Device.objects.create(mac=mac, name=name, whitelisted=whitelisted, mark=mark)
             device.save()
             return device
         except Exception as e:
-            netcontrol.disconnect_user(mac)
+            try:
+                netcontrol.disconnect_user(mac)
+            except requests.HTTPError as e:
+                raise ValidationError(
+                  _("Could not disconnect user.")
+                ) from e
             raise ValidationError(
               _("There was an error creating the device. Please try again.")
             ) from e
@@ -82,8 +93,13 @@ class DeviceManager(models.Manager):
         """
         Delete a device with the given mac address
         """
-        netcontrol.disconnect_user(mac)
-        logger.info("Disconnected device %s from the internet.", mac)
+        try:
+            netcontrol.disconnect_user(mac)
+            logger.info("Disconnected device %s from the internet.", mac)
+        except requests.HTTPError as e:
+            raise ValidationError(
+              _("Could not disconnect user.")
+            ) from e
 
         device = Device.objects.get(mac=mac)
         device.delete()
@@ -97,28 +113,42 @@ class DeviceManager(models.Manager):
         if not name:
             name = generate_dev_name()
 
-        r = netcontrol.get_mac(ip)
-        mac = r["mac"]
+        try:
+            mac = netcontrol.get_mac(ip)
+        except requests.HTTPError as e:
+            raise ValidationError(
+              _("Could not get MAC address.")
+            ) from e
 
         # Validate the MAC address
         validate_mac(mac)
 
         mark = get_mark(user)
-        netcontrol.connect_user(mac, mark, user.username)
 
-        logger.info(
-            "Connected device %s (owned by %s) at %s to the internet.",
-            mac,
-            user.username,
-            ip
-        )
+        try:
+            netcontrol.connect_user(mac, mark, user.username)
+            logger.info(
+                "Connected device %s (owned by %s) at %s to the internet.",
+                mac,
+                user.username,
+                ip
+            )
+        except requests.HTTPError as e:
+            raise ValidationError(
+              _("Could not connect user.")
+            ) from e
 
         try:
             device = UserDevice.objects.create(mac=mac, name=name, user=user, ip=ip, mark=mark)
             device.save()
             return device
         except Exception as e:
-            netcontrol.disconnect_user(mac)
+            try:
+                netcontrol.disconnect_user(mac)
+            except requests.HTTPError as e:
+                raise ValidationError(
+                  _("Could not disconnect user.")
+                ) from e
             raise ValidationError(
               _("There was an error creating the device. Please try again.")
             ) from e
@@ -141,16 +171,26 @@ class DeviceManager(models.Manager):
         if mac and mac != device.mac:
             validate_mac(mac)
             # Disconnect the old MAC
-            netcontrol.disconnect_user(device.mac)
-            # Connect the new MAC
-            netcontrol.connect_user(mac, device.mark, device.name)
-            device.mac = mac
+            try:
+                netcontrol.disconnect_user(device.mac)
+                # Connect the new MAC
+                netcontrol.connect_user(mac, device.mark, device.name)
+                device.mac = mac
+            except requests.HTTPError as e:
+                raise ValidationError(
+                    _("Could not connect user")
+                ) from e
         if mark and mark != device.mark:
             # Check if the mark is valid
             if mark not in [m["value"] for m in SETTINGS["marks"]]:
                 raise ValidationError(_("Invalid mark"))
             device.mark = mark
-            netcontrol.set_mark(device.mac, mark)
+            try:
+                netcontrol.set_mark(device.mac, mark)
+            except requests.HTTPError as e:
+                raise ValidationError(
+                    _("Could not set mark")
+                ) from e
 
         try:
             device.save()

--- a/backend/langate/network/tests.py
+++ b/backend/langate/network/tests.py
@@ -58,17 +58,17 @@ class TestDeviceManager(TestCase):
           password="password"
         )
 
-    def test_create_base_device_valid(self):
+    @patch('langate.network.models.netcontrol.connect_user', return_value = None)
+    @patch('langate.network.models.netcontrol.disconnect_user', return_value = None)
+    def test_create_base_device_valid(self, mock_connect_user, mock_disconnect_user):
         """
         Test the creation of a base device with valid parameters
         """
-        with patch('langate.network.models.netcontrol.query') as mock_query:
-            mock_query.return_value = None
-            device = DeviceManager.create_device(mac="00:11:22:33:44:55", name="TestDevice")
-            self.assertIsNotNone(device)
-            self.assertEqual(device.mac, "00:11:22:33:44:55")
-            self.assertEqual(device.name, "TestDevice")
-            self.assertFalse(device.whitelisted)
+        device = DeviceManager.create_device(mac="00:11:22:33:44:55", name="TestDevice")
+        self.assertIsNotNone(device)
+        self.assertEqual(device.mac, "00:11:22:33:44:55")
+        self.assertEqual(device.name, "TestDevice")
+        self.assertFalse(device.whitelisted)
 
     def test_create_device_invalid_mac(self):
         """
@@ -77,28 +77,28 @@ class TestDeviceManager(TestCase):
         with self.assertRaises(ValidationError):
             DeviceManager.create_device(mac="invalid_mac", name="TestDevice")
 
-    def test_create_device_no_name(self):
+    @patch('langate.network.models.generate_dev_name', return_value="GeneratedName")
+    @patch('langate.network.models.netcontrol.connect_user', return_value = None)
+    @patch('langate.network.models.netcontrol.disconnect_user', return_value = None)
+    def test_create_device_no_name(self, mock_gen_name, mock_connect_user, mock_disconnect_user):
         """
         Test the creation of a device with no name
         """
-        with patch('langate.network.models.netcontrol.query') as mock_query, \
-             patch('langate.network.models.generate_dev_name', return_value="GeneratedName") as mock_gen_name:
-            mock_query.return_value = None
-            device = DeviceManager.create_device(mac="00:11:22:33:44:55", name=None)
-            mock_gen_name.assert_called_once()
-            self.assertEqual(device.name, "GeneratedName")
+        device = DeviceManager.create_device(mac="00:11:22:33:44:55", name=None)
+        mock_gen_name.assert_called_once()
+        self.assertEqual(device.name, "GeneratedName")
 
+    @patch('langate.network.models.netcontrol.connect_user', return_value = None)
+    @patch('langate.network.models.netcontrol.disconnect_user', return_value = None)
     def test_create_whitelist_device_valid(self):
         """
         Test the creation of a whitelisted device with valid parameters
         """
-        with patch('langate.network.models.netcontrol.query') as mock_query:
-            mock_query.return_value = None
-            device = DeviceManager.create_device(mac="00:11:22:33:44:55", name="TestDevice", whitelisted=True)
-            self.assertIsNotNone(device)
-            self.assertEqual(device.mac, "00:11:22:33:44:55")
-            self.assertEqual(device.name, "TestDevice")
-            self.assertTrue(device.whitelisted)
+        device = DeviceManager.create_device(mac="00:11:22:33:44:55", name="TestDevice", whitelisted=True)
+        self.assertIsNotNone(device)
+        self.assertEqual(device.mac, "00:11:22:33:44:55")
+        self.assertEqual(device.name, "TestDevice")
+        self.assertTrue(device.whitelisted)
 
     def test_create_whitelist_device_invalid_mac(self):
         """
@@ -107,78 +107,62 @@ class TestDeviceManager(TestCase):
         with self.assertRaises(ValidationError):
             DeviceManager.create_device(mac="invalid_mac", name="TestDevice", whitelisted=True)
 
-    def test_create_whitelist_device_no_name(self):
+    @patch('langate.network.models.generate_dev_name', return_value="GeneratedName")
+    @patch('langate.network.models.netcontrol.connect_user', return_value = None)
+    @patch('langate.network.models.netcontrol.disconnect_user', return_value = None)
+    def test_create_whitelist_device_no_name(self, mock_gen_name , mock_connect_user, mock_disconnect_user):
         """
         Test the creation of a whitelisted device with no name
         """
-        with patch('langate.network.models.netcontrol.query') as mock_query, \
-             patch('langate.network.models.generate_dev_name', return_value="GeneratedName") as mock_gen_name:
-            mock_query.return_value = None
-            device = DeviceManager.create_device(mac="00:11:22:33:44:55", name=None, whitelisted=True)
-            mock_gen_name.assert_called_once()
-            self.assertEqual(device.name, "GeneratedName")
+        device = DeviceManager.create_device(mac="00:11:22:33:44:55", name=None, whitelisted=True)
+        mock_gen_name.assert_called_once()
+        self.assertEqual(device.name, "GeneratedName")
 
-    def test_create_user_device_valid(self):
+    @patch('langate.network.models.netcontrol.get_mac', return_value="00:11:22:33:44:55")
+    def test_create_user_device_valid(self, mock_get_mac):
         """
         Test the creation of a user device with valid parameters
         """
-        with patch('langate.network.models.netcontrol.query') as mock_query:
-            mock_query.return_value = {
-              "success": True,
-              "mac": "00:11:22:33:44:55",
-            }
-            device = DeviceManager.create_user_device(
-              user=self.user, ip="123.123.123.123", name="TestDevice"
-            )
-            self.assertIsNotNone(device)
-            self.assertEqual(device.mac, "00:11:22:33:44:55")
-            self.assertEqual(device.name, "TestDevice")
-            self.assertFalse(device.whitelisted)
-            self.assertEqual(device.user, self.user)
-            self.assertEqual(device.ip, "123.123.123.123")
+        device = DeviceManager.create_user_device(
+          user=self.user, ip="123.123.123.123", name="TestDevice"
+        )
+        self.assertIsNotNone(device)
+        self.assertEqual(device.mac, "00:11:22:33:44:55")
+        self.assertEqual(device.name, "TestDevice")
+        self.assertFalse(device.whitelisted)
+        self.assertEqual(device.user, self.user)
+        self.assertEqual(device.ip, "123.123.123.123")
 
-    def test_create_user_device_invalid_ip(self):
+    @patch('langate.network.models.netcontrol.get_mac', return_value="00:11:22:33:44:55")
+    def test_create_user_device_invalid_ip(self, mock_get_mac):
         """
         Test the creation of a user device with an invalid MAC address
         """
         with self.assertRaises(ValidationError):
-            with patch('langate.network.models.netcontrol.query') as mock_query:
-                mock_query.return_value = {
-                  "success": True,
-                  "mac": "00:11:22:33:44:55",
-                }
-                DeviceManager.create_user_device(
-                  user=self.user, ip="123.123.123.823", name="TestDevice"
-                )
+            DeviceManager.create_user_device(
+              user=self.user, ip="123.123.123.823", name="TestDevice"
+            )
 
-    def test_create_user_device_no_name(self):
+    @patch('langate.network.models.generate_dev_name', return_value="GeneratedName")
+    @patch('langate.network.models.netcontrol.get_mac', return_value="00:11:22:33:44:55")
+    def test_create_user_device_no_name(self, mock_gen_name, mock_get_mac):
         """
         Test the creation of a user device with no name
         """
-        with patch('langate.network.models.netcontrol.query') as mock_query, \
-             patch('langate.network.models.generate_dev_name', return_value="GeneratedName") as mock_gen_name:
-            mock_query.return_value = {
-              "success": True,
-              "mac": "00:11:22:33:44:55",
-            }
-            device = DeviceManager.create_user_device(
-              user=self.user, ip="123.123.123.123", name=None
-            )
-            mock_gen_name.assert_called_once()
-            self.assertEqual(device.name, "GeneratedName")
+        device = DeviceManager.create_user_device(
+          user=self.user, ip="123.123.123.123", name=None
+        )
+        mock_gen_name.assert_called_once()
+        self.assertEqual(device.name, "GeneratedName")
 
-    def test_create_device_duplicate_mac(self):
+    @patch('langate.network.models.netcontrol.get_mac', return_value="00:11:22:33:44:55")
+    def test_create_device_duplicate_mac(self, mock_get_mac):
         """
         Test the creation of a device with a duplicate MAC address
         """
-        with patch('langate.network.models.netcontrol.query') as mock_query:
-            mock_query.return_value = {
-              "success": True,
-              "mac": "00:11:22:33:44:55",
-            }
-            with self.assertRaises(ValidationError):
-                DeviceManager.create_device(mac="00:11:22:33:44:55", name="TestDevice")
-                DeviceManager.create_device(mac="00:11:22:33:44:55", name="TestDevice2")
+        with self.assertRaises(ValidationError):
+            DeviceManager.create_device(mac="00:11:22:33:44:55", name="TestDevice")
+            DeviceManager.create_device(mac="00:11:22:33:44:55", name="TestDevice2")
 
 class TestNetworkAPI(TestCase):
     """
@@ -286,11 +270,8 @@ class TestNetworkAPI(TestCase):
         """
         self.client.force_authenticate(user=self.user)
 
-        with patch('langate.network.models.netcontrol.query') as mock_query:
-            mock_query.return_value = {
-              "success": True,
-              "mac": self.device.mac,
-            }
+        with patch('langate.network.models.netcontrol.get_mac') as mock_get_mac:
+            mock_get_mac.return_value = self.device.mac
             response = self.client.delete(reverse('device-detail', args=[self.user_device.pk]))
             self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
@@ -333,11 +314,8 @@ class TestNetworkAPI(TestCase):
           'mac': '00:11:22:33:44:57',
           'name': 'new_name'
         }
-        with patch('langate.network.models.netcontrol.query') as mock_query:
-            mock_query.return_value = {
-              "success": True,
-              "mac": new_data['mac'],
-            }
+        with patch('langate.network.models.netcontrol.get_mac') as mock_get_mac:
+            mock_get_mac.return_value = new_data['mac']
             response = self.client.patch(reverse('device-detail', args=[self.device.pk]), new_data)
             self.device.refresh_from_db()
             self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -510,11 +488,8 @@ class TestNetworkAPI(TestCase):
           'mac': '00:11:22:33:44:57',
           'name': 'new_name'
         }
-        with patch('langate.network.models.netcontrol.query') as mock_query:
-            mock_query.return_value = {
-              "success": True,
-              "mac": new_data['mac'],
-            }
+        with patch('langate.network.models.netcontrol.get_mac') as mock_get_mac:
+            mock_get_mac.return_value = new_data['mac']
             response = self.client.post(reverse('device-list'), new_data)
             self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
@@ -533,11 +508,8 @@ class TestNetworkAPI(TestCase):
           'user': self.user.id,
         }
 
-        with patch('langate.network.models.netcontrol.query') as mock_query:
-            mock_query.return_value = {
-              "success": True,
-              "mac": "00:11:22:33:44:57",
-            }
+        with patch('langate.network.models.netcontrol.get_mac') as mock_get_mac:
+            mock_get_mac.return_value = "00:11:22:33:44:57"
             response = self.client.post(reverse('device-list'), new_data)
             self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 

--- a/backend/langate/network/tests.py
+++ b/backend/langate/network/tests.py
@@ -58,9 +58,9 @@ class TestDeviceManager(TestCase):
           password="password"
         )
 
-    @patch('langate.network.models.netcontrol.connect_user', return_value = None)
-    @patch('langate.network.models.netcontrol.disconnect_user', return_value = None)
-    def test_create_base_device_valid(self, mock_connect_user, mock_disconnect_user):
+    @patch('langate.settings.netcontrol.connect_user', return_value = None)
+    @patch('langate.settings.netcontrol.disconnect_user', return_value = None)
+    def test_create_base_device_valid(self, mock_disconnect_user, mock_connect_user):
         """
         Test the creation of a base device with valid parameters
         """
@@ -70,7 +70,9 @@ class TestDeviceManager(TestCase):
         self.assertEqual(device.name, "TestDevice")
         self.assertFalse(device.whitelisted)
 
-    def test_create_device_invalid_mac(self):
+    @patch('langate.settings.netcontrol.connect_user', return_value = None)
+    @patch('langate.settings.netcontrol.disconnect_user', return_value = None)
+    def test_create_device_invalid_mac(self, mock_disconnect_user, mock_connect_user):
         """
         Test the creation of a device with an invalid MAC address
         """
@@ -78,9 +80,9 @@ class TestDeviceManager(TestCase):
             DeviceManager.create_device(mac="invalid_mac", name="TestDevice")
 
     @patch('langate.network.models.generate_dev_name', return_value="GeneratedName")
-    @patch('langate.network.models.netcontrol.connect_user', return_value = None)
-    @patch('langate.network.models.netcontrol.disconnect_user', return_value = None)
-    def test_create_device_no_name(self, mock_gen_name, mock_connect_user, mock_disconnect_user):
+    @patch('langate.settings.netcontrol.connect_user', return_value = None)
+    @patch('langate.settings.netcontrol.disconnect_user', return_value = None)
+    def test_create_device_no_name(self, mock_disconnect_user, mock_connect_user, mock_gen_name):
         """
         Test the creation of a device with no name
         """
@@ -88,9 +90,9 @@ class TestDeviceManager(TestCase):
         mock_gen_name.assert_called_once()
         self.assertEqual(device.name, "GeneratedName")
 
-    @patch('langate.network.models.netcontrol.connect_user', return_value = None)
-    @patch('langate.network.models.netcontrol.disconnect_user', return_value = None)
-    def test_create_whitelist_device_valid(self):
+    @patch('langate.settings.netcontrol.connect_user', return_value = None)
+    @patch('langate.settings.netcontrol.disconnect_user', return_value = None)
+    def test_create_whitelist_device_valid(self, mock_disconnect_user, mock_connect_user):
         """
         Test the creation of a whitelisted device with valid parameters
         """
@@ -108,9 +110,9 @@ class TestDeviceManager(TestCase):
             DeviceManager.create_device(mac="invalid_mac", name="TestDevice", whitelisted=True)
 
     @patch('langate.network.models.generate_dev_name', return_value="GeneratedName")
-    @patch('langate.network.models.netcontrol.connect_user', return_value = None)
-    @patch('langate.network.models.netcontrol.disconnect_user', return_value = None)
-    def test_create_whitelist_device_no_name(self, mock_gen_name , mock_connect_user, mock_disconnect_user):
+    @patch('langate.settings.netcontrol.connect_user', return_value = None)
+    @patch('langate.settings.netcontrol.disconnect_user', return_value = None)
+    def test_create_whitelist_device_no_name(self, mock_disconnect_user, mock_connect_user, mock_gen_name):
         """
         Test the creation of a whitelisted device with no name
         """
@@ -118,8 +120,9 @@ class TestDeviceManager(TestCase):
         mock_gen_name.assert_called_once()
         self.assertEqual(device.name, "GeneratedName")
 
-    @patch('langate.network.models.netcontrol.get_mac', return_value="00:11:22:33:44:55")
-    def test_create_user_device_valid(self, mock_get_mac):
+    @patch('langate.settings.netcontrol.get_mac', return_value="00:11:22:33:44:55")
+    @patch('langate.settings.netcontrol.connect_user', return_value = None)
+    def test_create_user_device_valid(self,  mock_connect_user, mock_get_mac):
         """
         Test the creation of a user device with valid parameters
         """
@@ -133,8 +136,9 @@ class TestDeviceManager(TestCase):
         self.assertEqual(device.user, self.user)
         self.assertEqual(device.ip, "123.123.123.123")
 
-    @patch('langate.network.models.netcontrol.get_mac', return_value="00:11:22:33:44:55")
-    def test_create_user_device_invalid_ip(self, mock_get_mac):
+    @patch('langate.settings.netcontrol.get_mac', return_value="00:11:22:33:44:55")
+    @patch('langate.settings.netcontrol.connect_user', return_value = None)
+    def test_create_user_device_invalid_ip(self, mock_connect_user, mock_get_mac):
         """
         Test the creation of a user device with an invalid MAC address
         """
@@ -144,8 +148,9 @@ class TestDeviceManager(TestCase):
             )
 
     @patch('langate.network.models.generate_dev_name', return_value="GeneratedName")
-    @patch('langate.network.models.netcontrol.get_mac', return_value="00:11:22:33:44:55")
-    def test_create_user_device_no_name(self, mock_gen_name, mock_get_mac):
+    @patch('langate.settings.netcontrol.get_mac', return_value="00:11:22:33:44:55")
+    @patch('langate.settings.netcontrol.connect_user', return_value = None)
+    def test_create_user_device_no_name(self, mock_connect_user, mock_get_mac, mock_gen_name):
         """
         Test the creation of a user device with no name
         """
@@ -155,8 +160,9 @@ class TestDeviceManager(TestCase):
         mock_gen_name.assert_called_once()
         self.assertEqual(device.name, "GeneratedName")
 
-    @patch('langate.network.models.netcontrol.get_mac', return_value="00:11:22:33:44:55")
-    def test_create_device_duplicate_mac(self, mock_get_mac):
+    @patch('langate.settings.netcontrol.get_mac', return_value="00:11:22:33:44:55")
+    @patch('langate.settings.netcontrol.connect_user', return_value = None)
+    def test_create_device_duplicate_mac(self, mock_connect_user, mock_get_mac):
         """
         Test the creation of a device with a duplicate MAC address
         """
@@ -264,21 +270,21 @@ class TestNetworkAPI(TestCase):
         response = self.client.get(reverse('device-detail', args=[self.device.pk]))
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    def test_delete_device_success(self):
+    @patch('langate.settings.netcontrol.disconnect_user', return_value=None)
+    def test_delete_device_success(self, mock_disconnect_user):
         """
         Test the deletion of a device
         """
         self.client.force_authenticate(user=self.user)
 
-        with patch('langate.network.models.netcontrol.get_mac') as mock_get_mac:
-            mock_get_mac.return_value = self.device.mac
-            response = self.client.delete(reverse('device-detail', args=[self.user_device.pk]))
-            self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        response = self.client.delete(reverse('device-detail', args=[self.user_device.pk]))
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
-            self.assertFalse(Device.objects.filter(pk=self.user_device.pk).exists())
-            self.assertFalse(UserDevice.objects.filter(pk=self.user_device.pk).exists())
+        self.assertFalse(Device.objects.filter(pk=self.user_device.pk).exists())
+        self.assertFalse(UserDevice.objects.filter(pk=self.user_device.pk).exists())
 
-    def test_delete_device_not_found(self):
+    @patch('langate.settings.netcontrol.disconnect_user', return_value=None)
+    def test_delete_device_not_found(self, mock_disconnect_user):
         """
         Test the deletion of a non-existent device
         """
@@ -288,14 +294,16 @@ class TestNetworkAPI(TestCase):
         response = self.client.delete(url)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_delete_device_no_auth(self):
+    @patch('langate.settings.netcontrol.disconnect_user', return_value=None)
+    def test_delete_device_no_auth(self, mock_disconnect_user):
         """
         Test the deletion of a device without authentication
         """
         response = self.client.delete(reverse('device-detail', args=[self.device.pk]))
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    def test_delete_device_unauthorized(self):
+    @patch('langate.settings.netcontrol.disconnect_user', return_value=None)
+    def test_delete_device_unauthorized(self, mock_disconnect_user):
         """
         Test the deletion of a device by an unauthorized user
         """
@@ -304,7 +312,10 @@ class TestNetworkAPI(TestCase):
         response = self.client.delete(reverse('device-detail', args=[self.device.pk]))
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    def test_patch_device_success(self):
+    @patch('langate.settings.netcontrol.disconnect_user', return_value=None)
+    @patch('langate.settings.netcontrol.connect_user', return_value=None)
+    @patch('langate.settings.netcontrol.set_mark', return_value=None)
+    def test_patch_device_success(self, mock_set_mark, mock_connect_user, mock_disconnect_user):
         """
         Test the update of a device
         """
@@ -314,7 +325,7 @@ class TestNetworkAPI(TestCase):
           'mac': '00:11:22:33:44:57',
           'name': 'new_name'
         }
-        with patch('langate.network.models.netcontrol.get_mac') as mock_get_mac:
+        with patch('langate.settings.netcontrol.get_mac') as mock_get_mac:
             mock_get_mac.return_value = new_data['mac']
             response = self.client.patch(reverse('device-detail', args=[self.device.pk]), new_data)
             self.device.refresh_from_db()
@@ -478,7 +489,8 @@ class TestNetworkAPI(TestCase):
         response = self.client.get(reverse('user-devices'))
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    def test_post_device_success(self):
+    @patch('langate.settings.netcontrol.connect_user', return_value=None)
+    def test_post_device_success(self, mock_connect_user):
         """
         Test the creation of a device
         """
@@ -488,7 +500,7 @@ class TestNetworkAPI(TestCase):
           'mac': '00:11:22:33:44:57',
           'name': 'new_name'
         }
-        with patch('langate.network.models.netcontrol.get_mac') as mock_get_mac:
+        with patch('langate.settings.netcontrol.get_mac') as mock_get_mac:
             mock_get_mac.return_value = new_data['mac']
             response = self.client.post(reverse('device-list'), new_data)
             self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -496,7 +508,11 @@ class TestNetworkAPI(TestCase):
             device = Device.objects.get(mac='00:11:22:33:44:57')
             self.assertEqual(device.name, 'new_name')
 
-    def test_post_user_device_success(self):
+    @patch('langate.settings.netcontrol.disconnect_user', return_value=None)
+    @patch('langate.settings.netcontrol.connect_user', return_value=None)
+    @patch('langate.settings.netcontrol.set_mark', return_value=None)
+    @patch('langate.settings.netcontrol.get_mac', return_value="00:11:22:33:44:57")
+    def test_post_user_device_success(self, mock_get_mac, mock_set_mark, mock_connect_user, mock_disconnect_user):
         """
         Test the creation of a user device
         """
@@ -507,14 +523,11 @@ class TestNetworkAPI(TestCase):
           'name': 'new_name',
           'user': self.user.id,
         }
+        response = self.client.post(reverse('device-list'), new_data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-        with patch('langate.network.models.netcontrol.get_mac') as mock_get_mac:
-            mock_get_mac.return_value = "00:11:22:33:44:57"
-            response = self.client.post(reverse('device-list'), new_data)
-            self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-
-            device = UserDevice.objects.get(mac='00:11:22:33:44:57')
-            self.assertEqual(device.name, 'new_name')
+        device = UserDevice.objects.get(mac='00:11:22:33:44:57')
+        self.assertEqual(device.name, 'new_name')
 
     def test_post_device_invalid_data(self):
         """

--- a/backend/langate/settings.py
+++ b/backend/langate/settings.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from sys import argv
 import json
 import logging
+from langate.modules.netcontrol import Netcontrol
 
 from django.utils.translation import gettext_lazy as _
 from langate.network.utils import validate_marks, validate_games
@@ -254,3 +255,6 @@ else:
         SETTINGS["games"] = {}
 
 NETCONTROL_SOCKET_FILE = getenv("NETCONTROL_SOCKET_FILE", "/var/run/langate3000-netcontrol.sock")
+
+# Netcontrol interface
+netcontrol = Netcontrol()

--- a/backend/langate/user/views.py
+++ b/backend/langate/user/views.py
@@ -26,7 +26,7 @@ from langate.user.serializers import (
 )
 
 from .models import User, Role
-from langate.modules import netcontrol
+from langate.settings import netcontrol
 
 from langate.network.models import UserDevice, Device, DeviceManager
 from langate.network.serializers import UserDeviceSerializer
@@ -104,7 +104,7 @@ class UserMe(generics.RetrieveAPIView):
         if not user_devices.filter(ip=client_ip).exists():
           # If the user is still logged in but the device is not registered on the network,
           # we register it.
-          r = netcontrol.query("get_mac", { "ip": client_ip })
+          r = netcontrol.get_mac(client_ip)
           client_mac = r["mac"]
           try:
               # The following should never raise a MultipleObjectsReturned exception
@@ -228,7 +228,7 @@ class UserLogin(APIView):
 
             # If this device is not registered on the network, we register it.
             if not user_devices.filter(ip=client_ip).exists():
-                r = netcontrol.query("get_mac", { "ip": client_ip })
+                r = netcontrol.get_mac(client_ip)
                 client_mac = r["mac"]
                 try:
                     # The following should never raise a MultipleObjectsReturned exception

--- a/backend/langate/user/views.py
+++ b/backend/langate/user/views.py
@@ -1,4 +1,6 @@
 """User module API Endpoints"""
+import requests
+
 from functools import reduce
 from operator import or_
 
@@ -102,38 +104,42 @@ class UserMe(generics.RetrieveAPIView):
         client_ip = request.META.get('HTTP_X_FORWARDED_FOR')
 
         if not user_devices.filter(ip=client_ip).exists():
-          # If the user is still logged in but the device is not registered on the network,
-          # we register it.
-          r = netcontrol.get_mac(client_ip)
-          client_mac = r["mac"]
-          try:
-              # The following should never raise a MultipleObjectsReturned exception
-              # because it would mean that there are more than one devices
-              # already registered with the same MAC.
+            # If the user is still logged in but the device is not registered on the network,
+            # we register it.
+            try:
+                client_mac = netcontrol.get_mac(client_ip)
+            except requests.HTTPError as e:
+                raise ValidationError(
+                    _("Could not get MAC address")
+                ) from e
+            try:
+                # The following should never raise a MultipleObjectsReturned exception
+                # because it would mean that there are more than one devices
+                # already registered with the same MAC.
 
-              device = UserDevice.objects.get(mac=client_mac)
-              # If the device MAC is already registered on the network but with a different IP,
-              # This could happen if the DHCP has changed the IP of the client.
+                device = UserDevice.objects.get(mac=client_mac)
+                # If the device MAC is already registered on the network but with a different IP,
+                # This could happen if the DHCP has changed the IP of the client.
 
-              # * If the registered device is owned by another user, we delete the old device and we register the new one.
-              if device.user != request.user:
-                  if user_devices.count() >= request.user.max_device_nb:
-                      user["too_many_devices"] = True
-                      return Response(user, status=status.HTTP_200_OK)
-                  DeviceManager.delete_user_device(device)
+                # * If the registered device is owned by another user, we delete the old device and we register the new one.
+                if device.user != request.user:
+                    if user_devices.count() >= request.user.max_device_nb:
+                        user["too_many_devices"] = True
+                        return Response(user, status=status.HTTP_200_OK)
+                    DeviceManager.delete_user_device(device)
 
-                  DeviceManager.create_user_device(request.user, client_ip)
-              # * If the registered device is owned by the requesting user, we change the IP of the registered device.
-              else:
-                  device.ip = client_ip
-                  device.save()
+                    DeviceManager.create_user_device(request.user, client_ip)
+                # * If the registered device is owned by the requesting user, we change the IP of the registered device.
+                else:
+                    device.ip = client_ip
+                    device.save()
 
-          except UserDevice.DoesNotExist:
-              # If the device is not registered on the network, we register it.
-              if user_devices.count() >= request.user.max_device_nb:
-                  user["too_many_devices"] = True
-                  return Response(user, status=status.HTTP_200_OK)
-              DeviceManager.create_user_device(request.user, client_ip)
+            except UserDevice.DoesNotExist:
+                # If the device is not registered on the network, we register it.
+                if user_devices.count() >= request.user.max_device_nb:
+                    user["too_many_devices"] = True
+                    return Response(user, status=status.HTTP_200_OK)
+                DeviceManager.create_user_device(request.user, client_ip)
 
         user_devices = UserDevice.objects.filter(user=request.user)
 
@@ -228,8 +234,12 @@ class UserLogin(APIView):
 
             # If this device is not registered on the network, we register it.
             if not user_devices.filter(ip=client_ip).exists():
-                r = netcontrol.get_mac(client_ip)
-                client_mac = r["mac"]
+                try:
+                    client_mac = netcontrol.get_mac(client_ip)
+                except requests.HTTPError as e:
+                    raise ValidationError(
+                        _("Could not get MAC address")
+                    ) from e
                 try:
                     # The following should never raise a MultipleObjectsReturned exception
                     # because it would mean that there are more than one devices

--- a/docs/manuel/src/00-backend/netcontrol.md
+++ b/docs/manuel/src/00-backend/netcontrol.md
@@ -4,4 +4,14 @@ Netcontrol est le composant de la langate qui interface le backend avec la tête
 
 Il permet à la langate de pouvoir effectuer des opérations de plus bas niveau grace à un niveau de privilège plus élevé sur la tête.
 
-Il communique via sockets UNIX. Les informations sont précédées d'une annonce de leur taille, sous la forme d'un int de 4 octets. Les informations en elles-mêmes sont toujours des dictionnaires Python encodés en [pickle](https://docs.python.org/3/library/pickle.html).
+Le backend communique via des requêtes HTTP à l'API REST ([FastAPI](https://fastapi.tiangolo.com/)) du module netcontrol de la langate. L'adresse utilisée pour les requêtes est la route par défaut du docker du backend, sur laquelle est bind l'API.
+
+Pour effectuer ces requêtes, le backend dispose d'une classe Netcontrol, dans `langate/modules/netcontrol.py`, instanciée dans `langate/settings.py`. C'est cette instance qu'on utilise pour faire les requêtes, en l'important là où il y en a besoin. La classe Netcontrol possède une méthode par requête possible, avec les arguments spécifiques à chacune d'entre elles.
+
+## Faire les requêtes manuellement
+
+On peut utiliser `curl` pour simuler les requêtes au netcontrol depuis la tête de réseau en faisant attention au type de la requête (`GET`, `POST`, `DELETE` ou `PUT`). 
+Les requêtes se font ainsi : `curl -X {Type} http://{IP}:6784/{Arguments}` où :
+- `{Type}` est le type de la requête,
+- `{IP}` l'ip sur l'interface `docker0`,
+- `{Arguments}` les arguments sous la forme `endpoint?arg1=..&arg2=..&arg3=...` ou `endpoint` s'il n'y a pas d'argument. 


### PR DESCRIPTION
## Description

This PR enables the backend to send requests to the netcontrol API via http.

## Checklist

- [ ] I have tested the changes locally and they work as expected.
- [ ] I have tested the responsiveness of the changes and they work as expected.
- [x] I have assigned the pull request to the appropriate reviewer(s).
- [x] I have added labels to the pull request, if necessary.

