### PR TITLE
Fix disconnect button not clickable on mobile

### DIFF
--- a/frontend/src/components/Navigation.vue
+++ b/frontend/src/components/Navigation.vue
@@ -94,8 +94,10 @@ const burger_menu = ref(false);
           <img alt="Logo InsaLan" class="size-[40px]" src="@/assets/images/logo_retro.png"/>
         </router-link>
         <div
-          class="mx-5 flex flex-1 flex-col items-center justify-center"
+          class="mx-4 my-2 flex cursor-pointer flex-col justify-center text-center font-bold text-gray-400 hover:text-white"
           :class="{ hidden: !isConnected }"
+          @click="logout_user"
+          @keydown.enter="logout_user"
         >
           Déconnexion
         </div>


### PR DESCRIPTION
## Description

An oversight in the Navigation frontend made the "Déconnexion" text not a clickable button on mobile.

## Checklist

- [X] I have tested the changes locally and they work as expected.
- [X] I have documented the changes in docs/manuel, if necessary.
- [X] I have assigned the pull request to the appropriate reviewer(s).
- [X] I have added labels to the pull request, if necessary.

## Related Issues

Fix #49 