### PR TITLE
Allow mocking firewall rules and arp lookups

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,5 +1,7 @@
 # 1 is easier to debug, 0 is more secure
 DEV=1
+# Control whether netcontrol actually interacts with the host's network (for development purposes)
+MOCK_NETWORK=1
 # `gate.localhost` if you're on your laptop, `gate.insalan.fr` if you're
 # deploying the production website
 WEBSITE_HOST=gate.localhost

--- a/README.md
+++ b/README.md
@@ -32,27 +32,25 @@ You can also pass the `-d` argument to "detach" the container from the terminal,
 docker compose -f docker-compose-beta.yml down
 ```
 
-The website is available at the value of `WEBSITE_HOST` which should be `gate.insalan.fr` or `gate.localhost` depending on where it's running. Its API backend is available at `api.WEBSITE_HOST`.
-
 The "beta" environment is available at `beta.WEBSITE_HOST` and it's own API at `api.beta.WEBSITE_HOST`.
 
 There is hotreload for the front (with vite), back (with django runserver), and nginx (thanks to a custom script)
 
 ## Running the prod environment
 
-- Put 0 in the .env file for the `DEV` variable.
+- Put 0 in the .env file for the `DEV` and `MOCK_NETCONTROL` variables.
 
 - Build the images:
 ```sh
-docker compose -f docker-compose build
+docker compose build
 ```
 - Run the following command :
 ```sh
-docker compose -f docker-compose.yml up
+docker compose up
 ```
 - To stop the prod environment :
 ```sh
-docker compose -f docker-compose.yml down
+docker compose down
 ```
 
 The frontend is available at `WEBSITE_HOST` and its API at `api.WEBSITE_HOST`.

--- a/backend/langate/modules/netcontrol.py
+++ b/backend/langate/modules/netcontrol.py
@@ -1,5 +1,4 @@
 import requests
-import subprocess
 import logging
 
 GET_REQUESTS = ["get_mac", "get_ip", '']

--- a/backend/langate/modules/netcontrol.py
+++ b/backend/langate/modules/netcontrol.py
@@ -83,7 +83,7 @@ class Netcontrol:
         """
         Initialize HOST_IP to the docker's default route, set up REQUEST_URL and check the connection with the netcontrol API.
         """
-        self.HOST_IP = subprocess.run(["/sbin/ip", "route"], capture_output=True).stdout.decode("utf-8").split()[2]
+        self.HOST_IP = "host.docker.internal"
         self.REQUEST_URL = f"http://{self.HOST_IP}:6784/"
 
         self.logger = logging.getLogger(__name__)

--- a/docker-compose-beta.yml
+++ b/docker-compose-beta.yml
@@ -28,6 +28,8 @@ services:
       - 8000
     networks:
       - backend
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     links:
       - db
     depends_on:
@@ -102,6 +104,8 @@ services:
       context: ./netcontrol
       dockerfile: Dockerfile.dev
     image: langate/netcontrol
+    environment:
+      - MOCK_NETWORK=${MOCK_NETWORK}
     cap_add:
       - NET_ADMIN
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,8 @@ services:
       - 8000
     networks:
       - backend
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     links:
       - db
     depends_on:
@@ -92,6 +94,8 @@ services:
   netcontrol:
     build: ./netcontrol
     restart: unless-stopped
+    environment:
+      - MOCK_NETWORK=${MOCK_NETWORK}
     cap_add:
       - NET_ADMIN
     volumes:

--- a/netcontrol/Dockerfile
+++ b/netcontrol/Dockerfile
@@ -1,4 +1,4 @@
-	FROM python:3.12-alpine3.19
+FROM python:3.12-alpine3.19
 
 WORKDIR /nctl
 
@@ -12,4 +12,4 @@ RUN pip install -r /nctl/requirements.txt
 
 COPY . /nctl
 
-CMD ["fastapi", "run", "main.py", "--port", "6784"]
+CMD ["fastapi", "run", "main.py", "--host", "0.0.0.0", "--port", "6784"]

--- a/netcontrol/Dockerfile
+++ b/netcontrol/Dockerfile
@@ -12,4 +12,4 @@ RUN pip install -r /nctl/requirements.txt
 
 COPY . /nctl
 
-CMD ["fastapi", "run", "main.py", "--host", "0.0.0.0", "--port", "6784"]
+CMD ["fastapi", "run", "main.py", "--port", "6784"]

--- a/netcontrol/Dockerfile.dev
+++ b/netcontrol/Dockerfile.dev
@@ -12,4 +12,4 @@ RUN pip install -r /nctl/requirements.txt
 
 COPY . /nctl
 
-CMD ["fastapi", "dev", "main.py", "--port", "6784"]
+CMD ["fastapi", "dev", "main.py", "--host", "0.0.0.0", "--port", "6784"]

--- a/netcontrol/arp.py
+++ b/netcontrol/arp.py
@@ -22,7 +22,7 @@ class Arp:
                 if line.startswith(ip + " "):
                     mac = line[41:].split(" ")[0] # 41 is the position of the MAC address in the line
                     self.logger.info("Found MAC %s for IP %s", mac, ip)
-                    return { "mac" : mac}
+                    return { "mac" : mac }
             raise HTTPException(status_code=404, detail="MAC not found")
     
     def get_ip(self, mac: str):
@@ -39,5 +39,24 @@ class Arp:
                 if line[41:].split(" ")[0] == mac:
                     ip = line.split(" ")[0] # Extracting IP address
                     self.logger.info("Found IP %s for MAC %s", ip, mac)
-                    return { "ip" : ip}
+                    return { "ip" : ip }
             raise HTTPException(status_code=404, detail="IP not found")
+
+class MockedArp(Arp):
+    """
+    Class which *doesn't* interact with the ARP table
+    """
+    def __init__(self, logger: logging.Logger):
+        self.logger = logger
+    
+    def get_mac(self, ip: str):
+        self.logger.info("Querying MAC for IP %s", ip)
+        mac = "00:00:00:00:00:00"
+        self.logger.info("Found MAC %s for IP %s", mac, ip)
+        return { "mac" : mac }
+    
+    def get_ip(self, mac: str):
+        self.logger.info("Querying IP for MAC %s", mac)
+        ip = "127.0.0.1"
+        self.logger.info("Found IP %s for MAC %s", ip, mac)
+        return { "ip" : "127.0.0.1" }

--- a/netcontrol/main.py
+++ b/netcontrol/main.py
@@ -1,15 +1,23 @@
 from fastapi import FastAPI
 from contextlib import asynccontextmanager
+import os
 import logging
-from .nft import Nft
-from .arp import Arp
+from .nft import Nft, MockedNft
+from .arp import Arp, MockedArp
+
+mock = os.getenv("MOCK_NETWORK", "0") == "1"
 
 logger = logging.getLogger('uvicorn.error')
 # for some reason, default loggers are not working with FastAPI
 
-logger.info("Checking that nftables is working...")
-nft = Nft(logger)
-arp = Arp(logger)
+if mock:
+    logger.warning("MOCK_NETWORK is set to 1, Nftables rules will not be applied.")
+    nft = MockedNft(logger)
+    arp = MockedArp(logger)
+else:
+    nft = Nft(logger)
+    arp = Arp(logger)
+    logger.info("Checking that nftables is working...")
 nft.check_nftables()
 
 @asynccontextmanager

--- a/netcontrol/main.py
+++ b/netcontrol/main.py
@@ -17,7 +17,8 @@ if mock:
 else:
     nft = Nft(logger)
     arp = Arp(logger)
-    logger.info("Checking that nftables is working...")
+
+logger.info("Checking that nftables is working...")
 nft.check_nftables()
 
 @asynccontextmanager

--- a/netcontrol/nft.py
+++ b/netcontrol/nft.py
@@ -11,12 +11,12 @@ class Nft:
     """
     Class which interacts with the nftables backend
     """
-    def __init__(self, logger: logging.Logger):
+    def __init__(self, logger: logging.Logger) -> None:
         self.logger = logger
         self.nft = nftables.Nftables()
         self.nft.set_json_output(True)
 
-    def check_nftables(self):
+    def check_nftables(self) -> None:
         data = self._execute_nft_cmd("list ruleset")
         metainfo = data[0]["metainfo"]
         self.logger.info(f"Found running nftables version {metainfo['version']} with {len(data)} ruleset entries.")
@@ -43,7 +43,7 @@ class Nft:
         else:
             return json.loads(output)["nftables"]
 
-    def setup_portail(self):
+    def setup_portail(self) -> None:
         """
         Sets up the necessary nftables rules that block network access to unauthenticated devices, and marks packets based on the map
         """
@@ -73,7 +73,7 @@ class Nft:
 
         self.logger.info("Gate nftables set up")
         
-    def remove_portail(self):
+    def remove_portail(self) -> None:
         """
         Removes netcontrol-related chains, sets and maps from insalan table
         """
@@ -85,7 +85,7 @@ class Nft:
         
         self.logger.info("Gate nftables removed")
 
-    def set_mark(self, mac: str, mark: int):
+    def set_mark(self, mac: str, mark: int) -> None:
         """
         Changes mark of the given MAC address
         
@@ -97,7 +97,7 @@ class Nft:
         self.delete_user(mac)
         self.connect_user(mac, mark, "previously_connected_device")
 
-    def connect_user(self, mac: str, mark: int, name: str):
+    def connect_user(self, mac: str, mark: int, name: str) -> None:
         """
         Connects given device with given mark
         
@@ -140,10 +140,11 @@ class MockedNft(Nft):
     """
     Class which mocks the Nft class without actually executing nft commands
     """
-    def __init__(self, logger: logging.Logger):
+    def __init__(self, logger: logging.Logger) -> None:
         self.logger = logger
     
-    def check_nftables(self):
+    def check_nftables(self) -> None:
+        self.logger.info("Mocked Nftables OK")
         return
     
     def _execute_nft_cmd(self, cmd: str) -> dict:

--- a/netcontrol/nft.py
+++ b/netcontrol/nft.py
@@ -135,3 +135,16 @@ class Nft:
 
 class NftablesException(Exception):
     pass
+
+class MockedNft(Nft):
+    """
+    Class which mocks the Nft class without actually executing nft commands
+    """
+    def __init__(self, logger: logging.Logger):
+        self.logger = logger
+    
+    def check_nftables(self):
+        return
+    
+    def _execute_nft_cmd(self, cmd: str) -> dict:
+        return {}

--- a/netcontrol/nft.py
+++ b/netcontrol/nft.py
@@ -144,8 +144,10 @@ class MockedNft(Nft):
         self.logger = logger
     
     def check_nftables(self) -> None:
-        self.logger.info("Mocked Nftables OK")
-        return
+        self.logger.info("Mocked nftables OK")
     
     def _execute_nft_cmd(self, cmd: str) -> dict:
         return {}
+    
+    def setup_portail(self) -> None:
+        self.logger.info("Gate nftables set up")


### PR DESCRIPTION
## Description

This PR adds an environment variable for mocking the network aspects of netcontrol simply, without having to mock netcontrol entirely. This is useful when working on parts of the langate which don't involve netcontrol without being on the actual network head.

## Checklist

- [ ] I have tested the changes locally and they work as expected.
- [x] I have documented the changes in docs/manuel, if necessary.
- [x] I have assigned the pull request to the appropriate reviewer(s).
- [X] I have added labels to the pull request, if necessary.