### PR TITLE
Fix netcontrol segfault

### DIFF
--- a/docker-compose-beta.yml
+++ b/docker-compose-beta.yml
@@ -49,7 +49,7 @@ services:
       PGTZ: Europe/Paris
     volumes:
       - ./init_db.sql:/docker-entrypoint-initdb.d/init_db.sql
-      - ./volumes/beta/postgres/data:/var/lib/postgresql/data
+      - ./volumes/beta/postgres:/var/lib/postgresql
     expose:
       - 5432
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       PGTZ: Europe/Paris
     volumes:
       - ./init_db.sql:/docker-entrypoint-initdb.d/init_db.sql
-      - ./volumes/prod/postgres/data:/var/lib/postgresql/data
+      - ./volumes/prod/postgres:/var/lib/postgresql
     expose:
       - 5432
     healthcheck:

--- a/netcontrol/Dockerfile
+++ b/netcontrol/Dockerfile
@@ -1,14 +1,16 @@
-FROM python:3.12-alpine3.19
+FROM debian:bookworm-slim
 
 WORKDIR /nctl
 
-RUN apk add --no-cache nftables git \
-	&& pip install 'git+https://git.netfilter.org/nftables@v1.1.0#egg=nftables&subdirectory=py' \
-	&& apk del git
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		python3-pip \
+		python3-setuptools \
+		nftables \
+		python3-nftables
 
 COPY requirements.txt /nctl/
 
-RUN pip install -r /nctl/requirements.txt
+RUN python3 -m pip install --no-cache-dir --break-system-packages -r /nctl/requirements.txt
 
 COPY . /nctl
 

--- a/netcontrol/Dockerfile.dev
+++ b/netcontrol/Dockerfile.dev
@@ -1,14 +1,16 @@
-FROM python:3.12-alpine3.19
+FROM debian:bookworm-slim
 
 WORKDIR /nctl
 
-RUN apk add --no-cache nftables git \
-	&& pip install 'git+https://git.netfilter.org/nftables@v1.1.0#egg=nftables&subdirectory=py' \
-	&& apk del git
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		python3-pip \
+		python3-setuptools \
+		nftables \
+		python3-nftables
 
 COPY requirements.txt /nctl/
 
-RUN pip install -r /nctl/requirements.txt
+RUN python3 -m pip install --no-cache-dir --break-system-packages -r /nctl/requirements.txt
 
 COPY . /nctl
 

--- a/netcontrol/requirements.txt
+++ b/netcontrol/requirements.txt
@@ -1,3 +1,3 @@
-fastapi[standard]>=0.115.0,<0.116.0
+fastapi[standard]>=0.122.0,<0.123.0
 jsonschema>=4.23.0
 puresnmp>=2.0.1


### PR DESCRIPTION
## Description

This PR fixes (hopefully) the random crashes of netcontrol, by using a debian 12 slim image instead of an alpine and by upgrading fastapi. It also fixes an error I had with the db :

```
db-1  | Error: in 18+, these Docker images are configured to store database data in a
db-1  |        format which is compatible with "pg_ctlcluster" (specifically, using
db-1  |        major-version-specific directory names).  This better reflects how
db-1  |        PostgreSQL itself works, and how upgrades are to be performed.
db-1  | 
db-1  |        See also https://github.com/docker-library/postgres/pull/1259
db-1  | 
db-1  |        Counter to that, there appears to be PostgreSQL data in:
db-1  |          /var/lib/postgresql/data (unused mount/volume)
db-1  | 
db-1  |        This is usually the result of upgrading the Docker image without
db-1  |        upgrading the underlying database using "pg_upgrade" (which requires both
db-1  |        versions).
db-1  | 
db-1  |        The suggested container configuration for 18+ is to place a single mount
db-1  |        at /var/lib/postgresql which will then place PostgreSQL data in a
db-1  |        subdirectory, allowing usage of "pg_upgrade --link" without mount point
db-1  |        boundary issues.
db-1  | 
db-1  |        See https://github.com/docker-library/postgres/issues/37 for a (long)
db-1  |        discussion around this process, and suggestions for how to do so.
db-1 exited with code 1
dependency failed to start: container infra-langate-beta-db-1 exited (1)
```

## Checklist

- [x] I have tested the changes locally and they work as expected.
- [ ] I have documented the changes in docs/manuel, if necessary.
- [x] I have assigned the pull request to the appropriate reviewer(s).
- [x] I have added labels to the pull request, if necessary.

## Related Issues

Fixes #63
